### PR TITLE
docs: Update README files with SSE/WebSocket streaming support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Adds enterprise-grade authentication to any MCP server:
 - 🚀 **Single Binary**: No Docker, no dependencies - just download and run
 - 🛡️ **Modern Security**: OAuth 2.1 with PKCE, secure sessions, CSP headers
 - 📊 **Production Ready**: Prometheus metrics, health checks, OpenTelemetry tracing
-- 🔄 **Full Protocol Support**: HTTP, WebSocket, and MCP streaming
+- 🔄 **Full Protocol Support**: HTTP, SSE/WebSocket streaming, and MCP protocols
 - ⚡ **High Performance**: <10ms overhead, 1000+ concurrent connections
 
 ## 📦 Installation
@@ -172,6 +172,19 @@ The proxy is built with:
 
 See [docs/](docs/) for detailed architecture documentation.
 
+## 🔄 Recent Updates
+
+### v0.5.0 (Latest)
+- **SSE/WebSocket Streaming Support**: Fixed panic issues with streaming protocols
+- **Bypass Mode**: Added development/testing mode to bypass authentication
+- **Improved Stability**: Better error handling for long-lived connections
+- **AI-Assisted Development**: Code quality enhanced through Copilot and Gemini reviews
+
+### v0.4.0
+- **Monitoring & Observability**: Prometheus metrics and OpenTelemetry tracing
+- **Health Checks**: Built-in health endpoint with subsystem status
+- **Circuit Breaker**: Automatic backend failure protection
+
 ## 🤝 Contributing
 
 Contributions are welcome! Please feel free to submit a Pull Request.
@@ -184,6 +197,7 @@ MIT License - see [LICENSE](LICENSE) file for details.
 
 - Built for the [Model Context Protocol](https://modelcontextprotocol.io) ecosystem
 - Inspired by the need for simple, secure MCP server deployment
+- SSE/WebSocket streaming support developed for [mcp-proxy](https://github.com/sparfenyuk/mcp-proxy) compatibility
 
 ---
 

--- a/go/README.md
+++ b/go/README.md
@@ -19,10 +19,11 @@ This proxy sits between the internet and your MCP server, providing:
 - 🔐 **Universal OIDC**: Works with Auth0, Google, Microsoft, GitHub, or any OIDC provider
 - 🛡️ **Modern Security**: OAuth 2.1 + PKCE flow
 - 📊 **Production Ready**: Prometheus metrics, health checks, structured logging
-- 🔄 **Full Protocol Support**: HTTP, WebSocket, and streaming
+- 🔄 **Full Protocol Support**: HTTP, SSE/WebSocket streaming, and MCP protocols
 - ⚡ **High Performance**: <10ms overhead, handles 1000+ concurrent connections
 - 🔍 **Observability**: OpenTelemetry tracing, detailed metrics
 - 💾 **Flexible Sessions**: In-memory or Redis session storage
+- 🧪 **Bypass Mode**: Development/testing mode without authentication
 
 ## 🚀 Quick Start
 
@@ -316,6 +317,8 @@ For applications requiring different policies, consider modifying `DefaultSecuri
 - [x] Prometheus metrics
 - [x] OpenTelemetry tracing
 - [x] Circuit breaker & retry logic
+- [x] SSE/WebSocket streaming support
+- [x] Bypass mode for development
 - [x] Multi-platform binaries
 - [ ] Admin API for session management
 - [ ] Built-in rate limiting
@@ -335,3 +338,4 @@ This project is licensed under the MIT License - see the [LICENSE](../LICENSE) f
 - Built for the [Model Context Protocol](https://modelcontextprotocol.io) ecosystem
 - Inspired by the need for simple, secure MCP server deployment
 - Cloudflare Tunnels for making zero-trust access easy
+- SSE/WebSocket streaming support developed for [mcp-proxy](https://github.com/sparfenyuk/mcp-proxy) compatibility


### PR DESCRIPTION
## Summary
Updates documentation to reflect the new SSE/WebSocket streaming support added in v0.5.0.

## Changes
- Added v0.5.0 release notes highlighting streaming support
- Updated feature lists to mention SSE/WebSocket protocols  
- Added bypass mode to feature documentation
- Updated roadmap to show completed streaming support
- Added acknowledgment for mcp-proxy compatibility

## Related
- Follows PR #10 which implemented the streaming support